### PR TITLE
[UPD] OD-1397, revert OD18-92 migration hack up to commit bc017692

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -148,17 +148,13 @@ class ResUsersRoleLine(models.Model):
     date_from = fields.Date("From")
     date_to = fields.Date("To")
     is_enabled = fields.Boolean("Enabled", compute="_compute_is_enabled")
-
-    # Quatra custom: Avoid constraint error when loading this module during the
-    # migration to 18.0. base_user_role_company adapts the constraint to its
-    # altered implementation of user roles, but by then it is already too late.
-    # _sql_constraints = [
-    #     (
-    #         "user_role_uniq",
-    #         "unique (user_id,role_id)",
-    #         "User Roles can be assigned to a user only once at a time",
-    #     )
-    # ]
+    _sql_constraints = [
+        (
+            "user_role_uniq",
+            "unique (user_id,role_id)",
+            "Roles can be assigned to a user only once at a time",
+        )
+    ]
 
     @api.depends("date_from", "date_to")
     def _compute_is_enabled(self):


### PR DESCRIPTION
Re-enables the user_role_uniq SQL constraint on res.users.role.line by reverting a migration-only workaround, now that 18.0 go-live is complete (~1 year ago, mid-2025).

Reverted commit: 7305a966 ([MIG] OD18-92, base_user_role: disable invalid constraint). Merged onto the fork's 18.0 branch as bc017692 (squash of PR #5).

The remaining Quatra customizations on the fork (OD-1411 mssql uninstallable, OD-1411 notification_type constraint fix, OD-1019 notification_type reset) are preserved with their original SHAs; only 7305a966 is undone.

One conflict in base_user_role/models/role.py (unrelated upstream field-name-ambiguity fix 1ea6c9b7 touched the same block). Resolved by keeping the constraint text as it was pre-7305a966; the wording tweak from 1ea6c9b7 can come back in via the next OCA merge.

Notable changes for installed modules in this range:

base_user_role
  - re-enable user_role_uniq SQL constraint (previously commented out during migration)

Other server-backend modules: no changes.